### PR TITLE
BED-1567 - RW connection retries

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -7,9 +7,18 @@ exports.createRedisDataLoader = void 0;
 const lodash_1 = __importDefault(require("lodash"));
 const dataloader_1 = __importDefault(require("dataloader"));
 const json_stable_stringify_1 = __importDefault(require("json-stable-stringify"));
+function getErrorMessage(error) {
+    if (error instanceof Error)
+        return error.message;
+    return String(error);
+}
 function createRedisDataLoader(config) {
     const redisRW = config.redisRW;
     const redisRO = config.redisRO;
+    function isReplicaLoadingDataError(exception) {
+        const errorMessage = getErrorMessage(exception);
+        return errorMessage.includes('LOADING');
+    }
     function parse(resp) {
         if (resp === '' || resp === null) {
             return null;
@@ -39,16 +48,29 @@ function createRedisDataLoader(config) {
         const val = toString(rawVal);
         const fullKey = makeKey(keySpace, key, opt.cacheKeyFn);
         const multiRW = redisRW.multi();
-        const multiRO = redisRO.multi();
         multiRW.set(fullKey, val);
         if (opt.expire) {
             multiRW.expire(fullKey, opt.expire);
         }
         await multiRW.exec();
-        multiRO.get(fullKey);
-        const replies = await multiRO.exec();
-        const lastReply = lodash_1.default.last(replies);
-        return parse(lastReply);
+        try {
+            const multiRO = redisRO.multi();
+            multiRO.get(fullKey);
+            const replies = await multiRO.exec();
+            const lastReply = lodash_1.default.last(replies);
+            return parse(lastReply);
+        }
+        catch (ex) {
+            if (isReplicaLoadingDataError(ex)) {
+                // this replica is reloading from disc and not ready for work. retry
+                // loading these keys from the primary instead.
+                multiRW.get(fullKey);
+                const replies = await multiRW.exec();
+                const lastReply = lodash_1.default.last(replies);
+                return parse(lastReply);
+            }
+            throw ex;
+        }
     }
     // const rGet = async (keySpace: string, key: string, opt: RedisDataLoaderOptions) => {
     //   const result = await redisRO.get(makeKey(keySpace, key, opt.cacheKeyFn))
@@ -56,8 +78,19 @@ function createRedisDataLoader(config) {
     // }
     async function rMGet(keySpace, keys, opt) {
         const cacheKeys = lodash_1.default.map(keys, (k) => makeKey(keySpace, k, opt.cacheKeyFn));
-        const results = await redisRO.mGet(cacheKeys);
-        return results.map((result) => parse(result));
+        try {
+            const results = await redisRO.mGet(cacheKeys);
+            return results.map((result) => parse(result));
+        }
+        catch (ex) {
+            if (isReplicaLoadingDataError(ex)) {
+                // this replica is reloading from disc and not ready for work. retry
+                // loading these keys from the primary instead.
+                const results = await redisRW.mGet(cacheKeys);
+                return results.map((result) => parse(result));
+            }
+            throw ex;
+        }
     }
     async function rDel(keySpace, key, opt) {
         const cacheKey = makeKey(keySpace, key, opt.cacheKeyFn);
@@ -80,7 +113,9 @@ function createRedisDataLoader(config) {
                             .then((resp) => {
                             return rSetAndGet(this.keySpace, keys[index], resp, this.options);
                         })
-                            .then((r) => { return r === '' || lodash_1.default.isUndefined(r) ? null : r; });
+                            .then((r) => {
+                            return Promise.resolve(r === '' || lodash_1.default.isUndefined(r) ? null : r);
+                        });
                     }
                     else {
                         return Promise.resolve(result);


### PR DESCRIPTION
retry gets against RW connection if RO connection fails for LOADING events

@mwt-billy-bacon - the `src` directory is the one with changes. The `lib` directory is the built project ... you can ignore that.

Once this gets merged in, I'll update `hoopla-graphql` to use it, and I'll be able to test it out in our staging environment.